### PR TITLE
Unify nested variant handling

### DIFF
--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -240,6 +240,7 @@ impl ValueBuffer {
                 for (field_name, value) in obj.iter() {
                     object_builder.insert(field_name, value);
                 }
+                // TODO propagate error
                 object_builder.finish().unwrap();
             }
             Variant::List(list) => {
@@ -247,6 +248,7 @@ impl ValueBuffer {
                 for value in list.iter() {
                     list_builder.append_value(value);
                 }
+                // TOOD propagate error
                 list_builder.finish();
             }
         }


### PR DESCRIPTION
This PR targets the following from @friendlymatthew 
- https://github.com/apache/arrow-rs/pull/7914


The high level idea is to handle the low level recursion in `ValueBuffer`  in a uniform way

Then the higher level VariantBuilders simply call into that

I ran out of time today, but I think this approach is pretty promising